### PR TITLE
Clarify statement of application requirements

### DIFF
--- a/Proposed FANN charter_v2.txt
+++ b/Proposed FANN charter_v2.txt
@@ -1,6 +1,6 @@
 #Overview
 
-Modern network applications, ranging from AI/ML training to cloud services, require adaptive networks to ensure reliable and congestion-free data transfer within or across multiple data centers. However, existing traffic management mechanisms often face limitations in responsiveness, coverage, and operational complexity, particularly in high-speed, large-scale, dynamic network environments.
+Modern network applications, ranging from AI/ML training to cloud services, require high bandwidth, low delay, low jitter data transfer and depend on networks that are adaptive in the presence of faults, degradations, or congestion. However, existing traffic management mechanisms often face limitations in responsiveness, coverage, and operational complexity, particularly in high-speed, large-scale, dynamic network environments.
 
 Modern network hardware is capable of detecting congestion, microbursts and other local status at fine-grained time scales (ranging from microseconds to sub-millisecond), which outpaces the time needed for current mechanisms (e.g. control plane based information distribution or management plane based information collection） to disseminate such information to relevant network nodes for their actions (e.g., traffic engineering (TE), load balancing, flow control, and protection switching etc.), leading to suboptimal performance, delayed recovery, congestion, and inefficient resource utilization.
 


### PR DESCRIPTION
The old text brought up DCs. Sure they are important, but the scope does not need to mention them. On the other hand, the scope should be more clear about the network services that the applications require and the issues that need to be survived.